### PR TITLE
Tentative fix for the outOfBounds exception

### DIFF
--- a/organization-service/src/main/java/pl/piomin/services/quarkus/organization/client/LoadBalancedFilter.java
+++ b/organization-service/src/main/java/pl/piomin/services/quarkus/organization/client/LoadBalancedFilter.java
@@ -27,7 +27,7 @@ public class LoadBalancedFilter implements ClientRequestFilter {
 		HealthClient healthClient = consulClient.healthClient();
 		List<ServiceHealth> instances = healthClient
 				.getHealthyServiceInstances(uri.getHost()).getResponse();
-		ServiceHealth instance = instances.get(counter.getAndIncrement());
+		ServiceHealth instance = instances.get(counter.getAndIncrement()%instances.size());
 		URI u = UriBuilder.fromUri(uri)
 				.host(instance.getService().getAddress())
 				.port(instance.getService().getPort())


### PR DESCRIPTION
This is a tentative fix for issue when trying to call an instance number out of bounds.
If you set up 2 replicas, the increment of the counter at each call may lead to an ArrayOutOfBounds exception.
The proposed fix is to modulo with the number of instances in the registry.